### PR TITLE
feature/appointments-groomer-confirmation

### DIFF
--- a/src/components/dashboards/CustomerDashboard/cust-tabs.js
+++ b/src/components/dashboards/CustomerDashboard/cust-tabs.js
@@ -157,10 +157,11 @@ const CustTab = () => {
               {customerAppointments !== undefined ? (
                 customerAppointments.map(info => {
                   return (
-                    <div key={Date.now()} style={{ margin: '2%' }}>
+                    <div key={info.transaction} style={{ margin: '2%' }}>
                       <Card
                         hoverable
                         title={`${info.business_name}`}
+                        extra={`${info.confirmation}`}
                         style={{ width: 375, border: 'solid 0.8px black' }}
                       >
                         <h3>Certified Groomer:</h3>

--- a/src/components/dashboards/GroomerDashboard/groomer-tabs.js
+++ b/src/components/dashboards/GroomerDashboard/groomer-tabs.js
@@ -17,9 +17,15 @@ const GroomerTab = () => {
   const { authState } = useOktaAuth();
   const { resultInfo } = useContext(FormContext);
   const { groomerInfo, groomerAppointments } = useContext(GroomersContext);
-  const { getGroomerByID, getGroomerAppointments } = useContext(APIContext);
+  const {
+    getGroomerByID,
+    getGroomerAppointments,
+    editGroomerAppointmentConfirmation,
+  } = useContext(APIContext);
 
   const [mode] = useState('left');
+
+  const [click, setClick] = useState(0);
 
   var month = [
     'Jan',
@@ -36,11 +42,26 @@ const GroomerTab = () => {
     'Dec',
   ];
 
+  // const editConfirmation = async service => {
+  //   await editGroomerAppointmentConfirmation(authState);
+  // };
+
   useEffect(() => {
     getGroomerByID(authState);
     getGroomerAppointments();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [click]);
+
+  // useEffect(() => {
+
+  //   getGroomerAppointments();
+  //   // eslint-disable-next-line react-hooks/exhaustive-deps
+  // }, []);
+
+  // const confirmClick = (e) => {
+  //   e.preventDefault();
+  //   getGroomerAppointments();
+  // }
 
   return (
     console.log('Groomer appointments state', groomerAppointments),
@@ -142,11 +163,22 @@ const GroomerTab = () => {
             >
               {groomerAppointments !== undefined ? (
                 groomerAppointments.map(info => {
+                  let accepted = {
+                    confirmation: 'accepted',
+                    transaction_id: info.transaction,
+                  };
+                  let declined = {
+                    confirmation: 'declined',
+                    transaction_id: info.transaction,
+                  };
+                  console.log('Count clicks', click);
                   return (
-                    <div key={Date.now()} style={{ margin: '2%' }}>
+                    <div key={info.transaction} style={{ margin: '2%' }}>
                       <Card
                         hoverable
                         title={`${info.given_name} ${info.family_name}`}
+                        // Shows the status of the appointment and if it is pending, accepted, etc.
+                        extra={`${info.confirmation}`}
                         style={{ width: 300, border: 'solid 0.8px black' }}
                       >
                         <h3 style={{ marginTop: '2%' }}>Date:</h3>
@@ -214,8 +246,28 @@ const GroomerTab = () => {
                         <br />
                         <div style={{ paddingTop: '8%' }}>
                           <button>Reschedule</button>
-                          <button>Accept</button>
-                          <button>Decline</button>
+                          <button
+                            onClick={() => {
+                              editGroomerAppointmentConfirmation(
+                                authState,
+                                accepted
+                              );
+                              setClick(click + 1);
+                            }}
+                          >
+                            Accept
+                          </button>
+                          <button
+                            onClick={() => {
+                              editGroomerAppointmentConfirmation(
+                                authState,
+                                declined
+                              );
+                              setClick(click + 1);
+                            }}
+                          >
+                            Decline
+                          </button>
                         </div>
                       </Card>
                     </div>

--- a/src/state/contexts/APIContext.js
+++ b/src/state/contexts/APIContext.js
@@ -388,6 +388,22 @@ const APIProvider = ({ children }) => {
       });
   };
 
+  const editGroomerAppointmentConfirmation = (authState, confirmation) => {
+    const headers = getAuthHeader(authState);
+    return axios
+      .put(
+        `${process.env.REACT_APP_API_URI}/groomers/${userInfo.sub}/groomerSchedule/confirm`,
+        confirmation,
+        { headers }
+      )
+      .then(res => {
+        console.log('Successful appointment confirmation', res);
+      })
+      .catch(err => {
+        console.log('Failed appointment confirmation', err);
+      });
+  };
+
   /******************************************************************************
    *                      API calls for pets
    ******************************************************************************/
@@ -434,6 +450,7 @@ const APIProvider = ({ children }) => {
         postAppointment,
         getCustomerAppointments,
         getGroomerAppointments,
+        editGroomerAppointmentConfirmation,
       }}
     >
       {children}


### PR DESCRIPTION
When a groomer is viewing their appointments, they can now accept or decline incoming appointment requests. The very first button click may require two button clicks to refresh the appointment card, but any subsequent button clicks should work. Also, added appointment status to the upper right of each card. Reschedule button still in works and is currently inoperable.

## Description ##

DESCRIBE YOUR PULL REQUEST'S CHANGES AND REFERENCE THE FEATURE/USERSTORY/BUG IT'S REALATED TO.  REPLACE THIS TEXT.

## Type ##

- [ ] This is a bugfix.
- [ ] This is a new feature.
- [ ] This is part of a feature.

## Organization ##

- [ ] Have you linked this pull request to a Trello card?
- [ ] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing 

## Review ##

- [ ] Is this a work in progress?
- [ ] Is this ready to be reviewed?
- [ ] Have you added two reviewers to this pull request?
